### PR TITLE
docs: fix typo - remove duplicate word "be"

Fix typo

Removed "be" (#330)

### DIFF
--- a/src/api/composition-api-helpers.md
+++ b/src/api/composition-api-helpers.md
@@ -134,5 +134,5 @@ Used to generate unique-per-application IDs for accessibility attributes or form
   If you have more than one Vue application instance of the same page, you can avoid ID conflicts by giving each app an ID prefix via [`app.config.idPrefix`](/api/application#app-config-idprefix).
 
   :::warning Caution
-  `useId()` should be not be called inside a `computed()` property as it may cause instance conflicts. Instead, declare the ID outside of `computed()` and reference it within the computed function.
+  `useId()` should not be called inside a `computed()` property as it may cause instance conflicts. Instead, declare the ID outside of `computed()` and reference it within the computed function.
   :::


### PR DESCRIPTION
resolves #330
Cherry picked from https://github.com/vuejs/docs/commit/7989b5292f57ad6b9aa83d535d429a3fd1fbddc8