### PR TITLE
Fix a11y: improve sitemap link color contrast to meet WCAG AA

* Fix a11y: improve sitemap link color contrast to meet WCAG AA

* Address review comments: trying to some combination of colors, that would fit better. Not just having the headlines and links the same color. (#363)

### DIFF
--- a/.vitepress/theme/components/SiteMap.vue
+++ b/.vitepress/theme/components/SiteMap.vue
@@ -62,6 +62,8 @@ const items = nav
 
 #sitemap .vt-link {
   font-size: 0.9em;
-  color: var(--vt-c-text-2);
+  /* increased contrast for better legibility (WCAG 1.4.3) */
+  color: var(--vt-c-text-1);
+  opacity: 0.75;
 }
 </style>

--- a/src/guide/extras/render-function.md
+++ b/src/guide/extras/render-function.md
@@ -215,6 +215,33 @@ function render() {
 }
 ```
 
+### Using Vnodes in `<template>`
+
+```vue
+<script setup>
+import { h } from 'vue'
+
+const vnode = h('button', ['Hello'])
+</script>
+
+<template>
+  <!-- Via <component /> -->
+  <component :is="vnode">Hi</component>
+
+  <!-- Or directly as element -->
+  <vnode />
+  <vnode>Hi</vnode>
+</template>
+```
+
+A vnode object has been declared in `setup()`, you can use it like a normal component for rendering.
+
+:::warning
+A vnode represents an already created render output, not a component definition. Using a vnode in `<template>` does not create a new component instance, and the vnode will be rendered as-is.
+
+This pattern should be used with care and is not a replacement for normal components.
+:::
+
 ## JSX / TSX {#jsx-tsx}
 
 [JSX](https://facebook.github.io/jsx/) هو امتداد شبيه بـ XML لـ JavaScript يسمح لنا بكتابة شيفرة مثل هذه:


### PR DESCRIPTION
resolves #363
Cherry picked from https://github.com/vuejs/docs/commit/4610ff099114e7a75d3b1b7f4aa3b2ceed5d9d15