### PR TITLE
docs: fix typo in "Error Capturing Caveats" section (#384)

### DIFF
--- a/src/api/options-lifecycle.md
+++ b/src/api/options-lifecycle.md
@@ -223,7 +223,7 @@
 
   **Error Capturing Caveats**
   
-  - In components with async `setup()` function (with top-level `await`) Vue **will always** try to render component template, even if `setup()` throwed error. This will likely cause more errors because during render component's template might try to access non-existing properties of failed `setup()` context. When capturing errors in such components, be ready to handle errors from both failed async `setup()` (they will always come first) and failed render process.
+  - In components with async `setup()` function (with top-level `await`) Vue **will always** try to render component template, even if `setup()` threw error. This will likely cause more errors because during render component's template might try to access non-existing properties of failed `setup()` context. When capturing errors in such components, be ready to handle errors from both failed async `setup()` (they will always come first) and failed render process.
 
   - <sup class="vt-badge" data-text="SSR only"></sup> Replacing errored child component in parent component deep inside `<Suspense>` will cause hydration mismatches in SSR. Instead, try to separate logic that can possibly throw from child `setup()` into separate function and execute it in the parent component's `setup()`, where you can safely `try/catch` the execution process and make replacement if needed before rendering the actual child component.
 


### PR DESCRIPTION
resolves #384
Cherry picked from https://github.com/vuejs/docs/commit/fcec1ef7ded8604dd53f29b317af185aa26153db