### PR TITLE
complete Arabic translation of remaining English passages in Essentials guide

### DIFF
--- a/src/guide/essentials/component-basics.md
+++ b/src/guide/essentials/component-basics.md
@@ -6,7 +6,7 @@
 
 <!-- https://www.figma.com/file/qa7WHDQRWuEZNRs7iZRZSI/components -->
 
-This is very similar to how we nest native HTML elements, but Vue implements its own component model that allows us to encapsulate custom content and logic in each component. Vue also plays nicely with native Web Components. If you are curious about the relationship between Vue Components and native Web Components, [read more here](/guide/extras/web-components).
+هذا قريب جدًا من طريقة تداخل عناصر HTML الأصلية، لكن Vue تطبّق نموذج مكونات خاصًا يسمح بتغليف المحتوى والمنطق المخصص في كل مكون. كما تتعامل Vue بسلاسة مع مكونات الويب الأصلية (native Web Components). إذا رغبت في معرفة العلاقة بين مكونات Vue ومكونات الويب الأصلية، [اقرأ المزيد هنا](/guide/extras/web-components).
 
 
 

--- a/src/guide/essentials/computed.md
+++ b/src/guide/essentials/computed.md
@@ -288,7 +288,7 @@ export default {
   },
   computed: {
     // This computed will return the value of count when it's less or equal to 3.
-    // When count is >=4, the last value that fulfilled our condition will be returned
+    // عندما يكون count >= 4، يُرجع آخر قيمة حققت الشرط
     // instead until count is less or equal to 3
     alwaysSmall(_, previous) {
       if (this.count <= 3) {
@@ -311,7 +311,7 @@ import { ref, computed } from 'vue'
 const count = ref(2)
 
 // This computed will return the value of count when it's less or equal to 3.
-// When count is >=4, the last value that fulfilled our condition will be returned
+// عندما يكون count >= 4، يُرجع آخر قيمة حققت الشرط
 // instead until count is less or equal to 3
 const alwaysSmall = computed((previous) => {
   if (count.value <= 3) {

--- a/src/guide/essentials/computed.md
+++ b/src/guide/essentials/computed.md
@@ -128,7 +128,13 @@ const publishedBooksMessage = computed(() => {
 
 [اختبرها في حقل التجارب](https://play.vuejs.org/#eNp9Us1q20AQfpVhL3LAlkrbk3BUEgqFQm6ll24Pa2lsKbV2l52VSxA6NU0eI8eE3AK55E2kt8msrSSQv9vO3zff98224sDaeNOgSMWccldZD4S+sZnUVW2N89CCQ5X7aoNTyE1tG48FdLB0poaIJyOppc6NJg+q8aVxsP84MWmlBtCqxhSi76bU8NVgNA3JhTF/KIVf4Q0Q/WwQPsIMDoqN0jlv+NZUxdg6lj9x+VBRlb9S+8y1HyXC0Ql5dCfMCeC31N1eIJckoJ6oO1w+8LXNYl1RicVhIHOERGqFTP+hdzLZg/0MtiIcu+L0KDHeso/XqFe+hAw+wBeIhrP+bvgfAUsdTvtL5hDWz5OdrWwoBx5ru1YeOQKY22w4H06BB2/7Gxj+9df9VX/ZX8yT4D83kFU6a9s3iHYdg4eOsOURWUzF7nKzWtn4mIzm224lyLFAUqQ7USHHJwyxFKX3ltIkoWUefsQxxcatEn7FrtG+qjFGqmcLZ/4SOgaWYrzAFiPh5AbdzKEu0KF7D/NZ6wvcANuxfaK7B/XE7oo=)
 
-Here we have declared a computed property `publishedBooksMessage`. The `computed()` function expects to be passed a [getter function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get#description), and the returned value is a **computed ref**. Similar to normal refs, you can access the computed result as `publishedBooksMessage.value`. Computed refs are also auto-unwrapped in templates so you can reference them without `.value` in template expressions.
+لقد قمنا هنا بتعريف خاصية محسوبة باسم `publishedBooksMessage`.  
+دالة `computed()` تتوقع تمرير [دالة getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get#description) إليها، والقيمة المُعادة تكون **مرجعًا محسوبًا (computed ref)**.
+
+وبشكل مشابه للمراجع العادية (refs)، يمكنك الوصول إلى النتيجة باستخدام `publishedBooksMessage.value`.
+
+كما يتم فك التفاف (auto-unwrapped) المراجع المحسوبة تلقائيًا داخل القوالب (templates)، لذلك يمكنك استخدامها مباشرة بدون الحاجة إلى `.value` داخل تعبيرات القالب.
+
 
 خاصية محسوبة  تتبع تلقائيًا إعتمادياتها التفاعلية. يعرف Vue أن حساب `publishedBooksMessage` يعتمد على `author.books`، لذلك سيقوم بتحديث أي ربط يعتمد على `publishedBooksMessage` عند تغيير `author.books`.
 
@@ -257,19 +263,19 @@ const fullName = computed({
 
 </div>
 
-## Getting the Previous Value {#previous}
+## الحصول على القيمة السابقة {#previous}
 
-- Only supported in 3.4+
+- مدعومة فقط في الإصدار 3.4 وما فوق
+
 
 <p class="options-api">
-In case you need it, you can get the previous value returned by the computed property accessing
-the second argument of the getter:
+في حال احتجت إلى ذلك، يمكنك الحصول على القيمة السابقة التي أرجعتها الخاصية المحسوبة من خلال الوصول إلى الوسيط الثاني في دالة الـ getter:
 </p>
 
 <p class="composition-api">
-In case you need it, you can get the previous value returned by the computed property accessing
-the first argument of the getter:
+في حال احتجت إلى ذلك، يمكنك الحصول على القيمة السابقة التي أرجعتها الخاصية المحسوبة من خلال الوصول إلى الوسيط الأول في دالة الـ getter:
 </p>
+
 
 <div class="options-api">
 
@@ -318,7 +324,8 @@ const alwaysSmall = computed((previous) => {
 ```
 </div>
 
-In case you're using a writable computed:
+في حال كنت تستخدم خاصية محسوبة قابلة للكتابة (writable computed):
+
 
 <div class="options-api">
 
@@ -377,7 +384,13 @@ const alwaysSmall = computed({
 
 ### يجب أن تكون الدوال المحصلة خالية من التأثيرات الجانبية {#getters-should-be-side-effect-free}
 
-It is important to remember that computed getter functions should only perform pure computation and be free of side effects. For example, **don't mutate other state, make async requests, or mutate the DOM inside a computed getter!** Think of a computed property as declaratively describing how to derive a value based on other values - its only responsibility should be computing and returning that value. Later in the guide we will discuss how we can perform side effects in reaction to state changes with [watchers](./watchers).
+من المهم تذكّر أن دوال الـ computed getter يجب أن تقوم فقط بحسابات نقية (pure computation) وأن تكون خالية من أي تأثيرات جانبية (side effects).  
+على سبيل المثال، **لا تقم بتعديل حالة أخرى (state)، أو تنفيذ طلبات غير متزامنة (async)، أو التلاعب بالـ DOM داخل computed getter!**
+
+فكّر في الخاصية المحسوبة على أنها طريقة وصفية (declarative) لاشتقاق قيمة اعتمادًا على قيم أخرى — ومسؤوليتها الوحيدة هي حساب تلك القيمة وإرجاعها.
+
+لاحقًا في هذا الدليل، سنناقش كيف يمكن تنفيذ التأثيرات الجانبية استجابةً لتغيّرات الحالة باستخدام [watchers](./watchers).
+
 
 ### تجنب تعيين القيمة المحسوبة {#avoid-mutating-computed-value}
 

--- a/src/guide/essentials/conditional.md
+++ b/src/guide/essentials/conditional.md
@@ -70,11 +70,14 @@ const awesome = ref(true)
 </div>
 ```
 
-Similar to `v-else`, a `v-else-if` element must immediately follow a `v-if` or a `v-else-if` element.
+مشابهة لـ `v-else`، يجب أن يأتي عنصر `v-else-if` مباشرة بعد عنصر `v-if` أو عنصر `v-else-if`.
 
 ## `v-if` على `<template>` {#v-if-on-template}
 
-Because `v-if` is a directive, it has to be attached to a single element. But what if we want to toggle more than one element? In this case we can use `v-if` on a `<template>` element, which serves as an invisible wrapper. The final rendered result will not include the `<template>` element.
+بما أن `v-if` عبارة عن توجيه (directive)، فيجب ربطه بعنصر واحد فقط. ولكن ماذا لو أردنا إظهار أو إخفاء أكثر من عنصر؟
+
+في هذه الحالة يمكننا استخدام `v-if` على عنصر `<template>`، والذي يعمل كغلاف غير مرئي (invisible wrapper). النتيجة النهائية التي يتم عرضها لن تتضمن عنصر `<template>`.
+
 
 ```vue-html
 <template v-if="ok">
@@ -110,8 +113,9 @@ Because `v-if` is a directive, it has to be attached to a single element. But wh
 
 ## `v-if` مع `v-for` {#v-if-with-v-for}
 
-When `v-if` and `v-for` are both used on the same element, `v-if` will be evaluated first. See the [list rendering guide](list#v-for-with-v-if) for details.
+عندما يتم استخدام `v-if` و `v-for` على نفس العنصر، سيتم تقييم `v-if` أولًا. راجع [دليل عرض القوائم](list#v-for-with-v-if) لمزيد من التفاصيل.
 
-::: warning Note
-It's **not** recommended to use `v-if` and `v-for` on the same element due to implicit precedence. Refer to [list rendering guide](list#v-for-with-v-if) for details.
+::: warning ملاحظة
+لا يُنصح باستخدام `v-if` و `v-for` على نفس العنصر بسبب أولوية التنفيذ غير المباشرة. راجع [دليل عرض القوائم](list#v-for-with-v-if) لمزيد من التفاصيل.
 :::
+

--- a/src/guide/essentials/event-handling.md
+++ b/src/guide/essentials/event-handling.md
@@ -116,7 +116,9 @@ data() {
 
 </div>
 
-A method handler automatically receives the native DOM Event object that triggers it - in the example above, we are able to access the element dispatching the event via `event.target`.
+دالة المعالجة (method handler) تستقبل تلقائيًا كائن حدث الـ DOM الأصلي (native DOM Event) الذي يقوم بتشغيلها.  
+في المثال أعلاه، يمكننا الوصول إلى العنصر الذي أطلق الحدث من خلال `event.target`.
+
 
 <div class="composition-api">
 

--- a/src/guide/essentials/forms.md
+++ b/src/guide/essentials/forms.md
@@ -442,7 +442,11 @@ export default {
 <input v-model.number="age" />
 ```
 
-If the value cannot be parsed with `parseFloat()`, then the original (string) value is used instead. In particular, if the input is empty (for instance after the user clearing the input field), an empty string is returned. This behavior differs from the [DOM property `valueAsNumber`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#valueasnumber). 
+إذا تعذّر تحليل القيمة باستخدام `parseFloat()`، فسيتم استخدام القيمة الأصلية (كنص) بدلًا من ذلك.  
+وبشكل خاص، إذا كان الإدخال فارغًا (مثل حالة قيام المستخدم بمسح حقل الإدخال)، فسيتم إرجاع سلسلة نصية فارغة.
+
+هذا السلوك يختلف عن خاصية الـ DOM `valueAsNumber` الخاصة بـ [HTMLInputElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement#valueasnumber).
+
 
 المُعدِّل `number` يُطبَّق تلقائيًا إذا كان الإدخال لديه السمة `type="number"` .
 

--- a/src/guide/essentials/list.md
+++ b/src/guide/essentials/list.md
@@ -245,15 +245,16 @@ data() {
 </template>
 ```
 
-:::warning Note
-It's **not** recommended to use `v-if` and `v-for` on the same element due to implicit precedence.
+:::warning ملاحظة
+لا يُنصح باستخدام `v-if` و `v-for` على نفس العنصر بسبب أولوية التنفيذ الضمنية.
 
-There are two common cases where this can be tempting:
+هناك حالتان شائعتان قد تدفعان لاستخدامهما معًا:
 
-- To filter items in a list (e.g. `v-for="user in users" v-if="user.isActive"`). In these cases, replace `users` with a new computed property that returns your filtered list (e.g. `activeUsers`).
+- لتصفية عناصر في قائمة (مثل `v-for="user in users" v-if="user.isActive"`). في هذه الحالة، استبدل `users` بخاصية محسوبة جديدة تُرجع القائمة بعد تصفيتها (مثل `activeUsers`).
 
-- To avoid rendering a list if it should be hidden (e.g. `v-for="user in users" v-if="shouldShowUsers"`). In these cases, move the `v-if` to a container element (e.g. `ul`, `ol`).
+- لتجنب عرض قائمة بالكامل إذا كان يجب إخفاؤها (مثل `v-for="user in users" v-if="shouldShowUsers"`). في هذه الحالة، انقل `v-if` إلى عنصر حاوي (مثل `ul` أو `ol`).
 :::
+
 
 ## الحفاظ على الحالة مع `key` {#maintaining-state-with-key}
 

--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -469,7 +469,7 @@ console.log(proxy.nested === raw) // false
 
 ### كخاصية لكائن تفاعلي (reactive) \*\* {#ref-unwrapping-as-reactive-object-property}
 
-A ref is automatically unwrapped when accessed or mutated as a property of a reactive object. In other words, it behaves like a normal property:
+يتم إلغاء تغليف المرجع تلقائيًا عند الوصول إليه أو تحوره كخاصية لكائن تفاعلي. وبعبارة أخرى، فإنه يتصرف مثل الممتلكات العادية:
 
 ```js
 const count = ref(0)

--- a/src/guide/essentials/reactivity-fundamentals.md
+++ b/src/guide/essentials/reactivity-fundamentals.md
@@ -277,8 +277,6 @@ export default {
 
 في Vue، الحالة تفاعلية عميقة بشكل افتراضي. هذا يعني أنه يمكنك توقع كشف التغييرات حتى عند تغيير الكائنات المتداخلة أو المصفوفات:
 
-In Vue, state is deeply reactive by default. This means you can expect changes to be detected even when you mutate nested objects or arrays:
-
 ```js
 export default {
   data() {

--- a/src/guide/essentials/template-refs.md
+++ b/src/guide/essentials/template-refs.md
@@ -6,20 +6,19 @@
 <input ref="input">
 ```
 
-`ref` هو سمة خاصة، مماثلة لسمة `key` التي تم مناقشتها في محور `v-for`. يسمح لنا بالحصول على مرجع مباشر لعنصر DOM محدد أو نسخة مكون ابن بعد وصله. قد يكون هذا مفيدًا عندما تريد، على سبيل المثال، التركيز برمجيًا على عنصر إدخال  على مكون موصول بالـDOM أو تهيئة مكتبة طرف ثالث على عنصر معين.
-`ref` هو سمة خاصة، مماثلة لسمة `key` التي تم مناقشتها في محور `v-for`. يسمح لنا بالحصول على مرجع مباشر لعنصر DOM محدد أو نسخة مكون ابن بعد وصله. قد يكون هذا مفيدًا عندما تريد، على سبيل المثال، التركيز برمجيًا على عنصر إدخال  على مكون موصول بالـDOM أو تهيئة مكتبة طرف ثالث على عنصر معين.
+`ref` هو سمة خاصة، مماثلة لسمة `key` التي تم مناقشتها في محور `v-for`. يسمح لنا بالحصول على مرجع مباشر لعنصر DOM محدد أو نسخة مكون ابن بعد وصله. قد يكون هذا مفيدًا عندما تريد، على سبيل المثال، التركيز برمجيًا على عنصر إدخال على مكون موصول بالـ DOM أو تهيئة مكتبة طرف ثالث على عنصر معين.
 
 ## الوصول إلى المراجع {#accessing-the-refs}
 
 <div class="composition-api">
 
-To obtain the reference with Composition API, we can use the [`useTemplateRef()`](/api/composition-api-helpers#usetemplateref) <sup class="vt-badge" data-text="3.5+" /> helper:
+للحصول على المرجع باستخدام الواجهة التركيبية (Composition API)، يمكننا استخدام الدالة المساعدة [`useTemplateRef()`](/api/composition-api-helpers#usetemplateref) <sup class="vt-badge" data-text="3.5+" />:
 
 ```vue
 <script setup>
 import { useTemplateRef, onMounted } from 'vue'
 
-// the first argument must match the ref value in the template
+// يجب أن يطابق الوسيط الأول قيمة `ref` في القالب
 const input = useTemplateRef('my-input')
 
 onMounted(() => {
@@ -32,12 +31,12 @@ onMounted(() => {
 </template>
 ```
 
-When using TypeScript, Vue's IDE support and `vue-tsc` will automatically infer the type of `input.value` based on what element or component the matching `ref` attribute is used on.
+عند استخدام TypeScript، يستنتج دعم Vue في المحرّر و`vue-tsc` تلقائيًا نوع `input.value` حسب العنصر أو المكون الذي تُستخدم عليه سمة `ref` المطابقة.
 
 <details>
-<summary>Usage before 3.5</summary>
+<summary>الاستخدام قبل الإصدار 3.5</summary>
 
-In versions before 3.5 where `useTemplateRef()` was not introduced, we need to declare a ref with a name that matches the template ref attribute's value:
+في الإصدارات السابقة لـ 3.5 حيث لم تُعرَف `useTemplateRef()` بعد، نحتاج إلى التصريح بمرجع (`ref`) اسمه يطابق قيمة سمة مرجع القالب في القالب:
 
 ```vue
 <script setup>
@@ -93,7 +92,7 @@ export default {
 
 </div>
 
-Note that you can only access the ref **after the component is mounted.** If you try to access <span class="options-api">`$refs.input`</span><span class="composition-api">`input`</span> in a template expression, it will be <span class="options-api">`undefined`</span><span class="composition-api">`null`</span> on the first render. This is because the element doesn't exist until after the first render!
+لاحظ أنه يمكنك الوصول إلى المرجع فقط **بعد وصل المكون (mount).** إذا حاولت الوصول إلى <span class="options-api">`$refs.input`</span><span class="composition-api">`input`</span> في تعبير القالب، ستكون القيمة <span class="options-api">`undefined`</span><span class="composition-api">`null`</span> في التصيير الأول. ذلك لأن العنصر لا يوجد حتى بعد التصيير الأول!
 
 <div class="composition-api">
 
@@ -115,7 +114,7 @@ watchEffect(() => {
 
 ## المراجع داخل حلقات `v-for` {#refs-inside-v-for}
 
-> Requires v3.5 or above
+> يتطلب الإصدار 3.5 أو أحدث
 
 <div class="composition-api">
 
@@ -143,12 +142,12 @@ onMounted(() => console.log(itemRefs.value))
 </template>
 ```
 
-[Try it in the Playground](https://play.vuejs.org/#eNp9UsluwjAQ/ZWRLwQpDepyQoDUIg6t1EWUW91DFAZq6tiWF4oU5d87dtgqVRyyzLw3b+aN3bB7Y4ptQDZkI1dZYTw49MFMuBK10dZDAxZXOQSHC6yNLD3OY6zVsw7K4xJaWFldQ49UelxxVWnlPEhBr3GszT6uc7jJ4fazf4KFx5p0HFH+Kme9CLle4h6bZFkfxhNouAIoJVqfHQSKbSkDFnVpMhEpovC481NNVcr3SaWlZzTovJErCqgydaMIYBRk+tKfFLC9Wmk75iyqg1DJBWfRxT7pONvTAZom2YC23QsMpOg0B0l0NDh2YjnzjpyvxLrYOK1o3ckLZ5WujSBHr8YL2gxnw85lxEop9c9TynkbMD/kqy+svv/Jb9wu5jh7s+jQbpGzI+ZLu0byEuHZ+wvt6Ays9TJIYl8A5+i0DHHGjvYQ1JLGPuOlaR/TpRFqvXCzHR2BO5iKg0Zmm/ic0W2ZXrB+Gve2uEt1dJKs/QXbwePE)
+[اختبرها في حقل التجارب](https://play.vuejs.org/#eNp9UsluwjAQ/ZWRLwQpDepyQoDUIg6t1EWUW91DFAZq6tiWF4oU5d87dtgqVRyyzLw3b+aN3bB7Y4ptQDZkI1dZYTw49MFMuBK10dZDAxZXOQSHC6yNLD3OY6zVsw7K4xJaWFldQ49UelxxVWnlPEhBr3GszT6uc7jJ4fazf4KFx5p0HFH+Kme9CLle4h6bZFkfxhNouAIoJVqfHQSKbSkDFnVpMhEpovC481NNVcr3SaWlZzTovJErCqgydaMIYBRk+tKfFLC9Wmk75iyqg1DJBWfRxT7pONvTAZom2YC23QsMpOg0B0l0NDh2YjnzjpyvxLrYOK1o3ckLZ5WujSBHr8YL2gxnw85lxEop9c9TynkbMD/kqy+svv/Jb9wu5jh7s+jQbpGzI+ZLu0byEuHZ+wvt6Ays9TJIYl8A5+i0DHHGjvYQ1JLGPuOlaR/TpRFqvXCzHR2BO5iKg0Zmm/ic0W2ZXrB+Gve2uEt1dJKs/QXbwePE)
 
 <details>
-<summary>Usage before 3.5</summary>
+<summary>الاستخدام قبل الإصدار 3.5</summary>
 
-In versions before 3.5 where `useTemplateRef()` was not introduced, we need to declare a ref with a name that matches the template ref attribute's value. The ref should also contain an array value:
+في الإصدارات السابقة لـ 3.5 حيث لم تُعرَف `useTemplateRef()` بعد، نحتاج إلى التصريح بمرجع (`ref`) اسمه يطابق قيمة سمة مرجع القالب في القالب. يجب أن يحمل المرجع أيضًا قيمة مصفوفة:
 
 ```vue
 <script setup>
@@ -236,7 +235,7 @@ import Child from './Child.vue'
 const childRef = useTemplateRef('child')
 
 onMounted(() => {
-  // childRef.value will hold an instance of <Child />
+  // childRef.value سيحتوي على نسخة من <Child />
 })
 </script>
 
@@ -246,7 +245,7 @@ onMounted(() => {
 ```
 
 <details>
-<summary>Usage before 3.5</summary>
+<summary>الاستخدام قبل الإصدار 3.5</summary>
 
 ```vue
 <script setup>
@@ -314,9 +313,9 @@ defineExpose({
 
 عندما يحصل المكون الأب على نسخة من هذا المكون عبر مراجع القالب، سيكون المكون المسترجع على الشكل `{ a: number, b: number }` (المراجع تُفك تلقائياً مثل المكونات العادية).
 
-Note that defineExpose must be called before any await operation. Otherwise, properties and methods exposed after the await operation will not be accessible. 
+تنبّه إلى أنه يجب استدعاء `defineExpose` قبل أي عملية `await`. وإلا فلن يمكن الوصول إلى الخصائص والدوال المعرّفة بعد عملية الـ `await`.
 
-See also: [Typing Component Template Refs](/guide/typescript/composition-api#typing-component-template-refs) <sup class="vt-badge ts" />
+اطلع أيضًا على: [إضافة الأنواع لمراجع مكونات القالب](/guide/typescript/composition-api#typing-component-template-refs) <sup class="vt-badge ts" />
 
 </div>
 <div class="options-api">

--- a/src/guide/essentials/template-syntax.md
+++ b/src/guide/essentials/template-syntax.md
@@ -64,21 +64,21 @@ Vue تستخدم صيغة القالب المستند على الـHTML التي
 
 > فيما يلي من الدليل، سنستخدم الصيغة المختصرة في أمثلة الشيفرة، لأنها هي الأكثر استخدامًا من طرف مطوري Vue.
 
-### Same-name Shorthand {#same-name-shorthand}
+### اختصار الاسم المطابق (same-name shorthand) {#same-name-shorthand}
 
-- Only supported in 3.4+
+- مدعوم فقط في الإصدار 3.4 وما فوق
 
-If the attribute has the same name as the variable name of the JavaScript value being bound, the syntax can be further shortened to omit the attribute value:
+إذا كانت السمة تحمل نفس اسم المتغير في JavaScript للقيمة المربوطة، يمكن اختصار الصياغة أكثر بحذف قيمة السمة:
 
 ```vue-html
-<!-- same as :id="id" -->
+<!-- نفس :id="id" -->
 <div :id></div>
 
-<!-- this also works -->
+<!-- هذا يعمل أيضًا -->
 <div v-bind:id></div>
 ```
 
-This is similar to the property shorthand syntax when declaring objects in JavaScript. Note this is a feature that is only available in Vue 3.4 and above.
+هذا يشبه اختصار الخاصية (property shorthand) عند التصريح بكائنات في JavaScript. هذه ميزة متوفرة فقط في Vue 3.4 وما فوق.
 
 ### السمات المنطقية {#boolean-attributes}
 

--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -144,7 +144,7 @@ watch(obj.count, (count) => {
 watch(
   () => obj.count,
   (count) => {
-    console.log(`Count is: ${count}`)
+    console.log(`العداد: ${count}`)
   }
 )
 ```
@@ -279,7 +279,7 @@ export default {
   watch: {
     source: {
       handler(newValue, oldValue) {
-        // when `source` changes, triggers only once
+        // عند تغيّر `source`، يُشغَّل مرة واحدة فقط
       },
       once: true
     }
@@ -295,7 +295,7 @@ export default {
 watch(
   source,
   (newValue, oldValue) => {
-    // when `source` changes, triggers only once
+    // عند تغيّر `source`، يُشغَّل مرة واحدة فقط
   },
   { once: true }
 )
@@ -342,7 +342,7 @@ watchEffect(async () => {
 
 يمكنك التحقق من [هذا المثال](/examples/#fetching-data) لـ `()watchEffect` و كيفية تحميل البيانات التفاعلية داخل دالتها المعالجة.
 
-بالنسبة للأمثلة مثل هذه، مع اعتمادية واحدة فقط، فإن فائدة `()watchEffect` غير ملموسة نسبيا. ولكن hلدوال المُراقِبة التي لديها عدة اعتماديات، فإن استخدام `()watchEffect` يزيل قائمة الاعتماديات المضافة يدويًا. بالإضافة إلى ذلك، إذا كنت بحاجة إلى مراقبة عدة خاصيات في سلسلة بيانات متداخلة، فقد تثبت الدالة `()watchEffect`  فعاليتها مقارنة بالدالة المُراقِبة العميقة، حيث سيتم تتبع الخاصيات المستخدمة فقط في الدالة المعالجة، بدلاً من تتبعها جميعا بشكل تكراري .
+بالنسبة للأمثلة مثل هذه، مع اعتمادية واحدة فقط، فإن فائدة `()watchEffect` غير ملموسة نسبيا. ولكن للدوال المُراقِبة التي لديها عدة اعتماديات، فإن استخدام `()watchEffect` يزيل قائمة الاعتماديات المضافة يدويًا. بالإضافة إلى ذلك، إذا كنت بحاجة إلى مراقبة عدة خاصيات في سلسلة بيانات متداخلة، فقد تثبت الدالة `()watchEffect`  فعاليتها مقارنة بالدالة المُراقِبة العميقة، حيث سيتم تتبع الخاصيات المستخدمة فقط في الدالة المعالجة، بدلاً من تتبعها جميعا بشكل تكراري .
 
 :::tip ملاحظة
 `()watchEffect` يتتبع الاعتماديات فقط خلال تنفيذها **المتزامن**. عند استخدامه مع دالة مُعالِجة غير متزامنة، وحدها الخاصيات التي يتم الوصول إليها قبل النبضة الأولى لـ`await` ستُتبَّع .
@@ -368,7 +368,7 @@ watchEffect(async () => {
 ```js
 watch(id, (newId) => {
   fetch(`/api/${newId}`).then(() => {
-    // callback logic
+    // منطق الـ callback
   })
 })
 ```
@@ -381,7 +381,7 @@ export default {
   watch: {
     id(newId) {
       fetch(`/api/${newId}`).then(() => {
-        // callback logic
+        // منطق الـ callback
       })
     }
   }
@@ -405,11 +405,11 @@ watch(id, (newId) => {
   const controller = new AbortController()
 
   fetch(`/api/${newId}`, { signal: controller.signal }).then(() => {
-    // callback logic
+    // منطق الـ callback
   })
 
   onWatcherCleanup(() => {
-    // abort stale request
+    // إلغاء الطلب القديم
     controller.abort()
   })
 })
@@ -427,11 +427,11 @@ export default {
       const controller = new AbortController()
 
       fetch(`/api/${newId}`, { signal: controller.signal }).then(() => {
-        // callback logic
+        // منطق الـ callback
       })
 
       onWatcherCleanup(() => {
-        // abort stale request
+        // إلغاء الطلب القديم
         controller.abort()
       })
     }
@@ -441,9 +441,9 @@ export default {
 
 </div>
 
-Note that `onWatcherCleanup` is only supported in Vue 3.5+ and must be called during the synchronous execution of a `watchEffect` effect function or `watch` callback function: you cannot call it after an `await` statement in an async function.
+لاحظ أن `onWatcherCleanup` مدعومة فقط في Vue 3.5+ ويجب استدعاؤها أثناء التنفيذ المتزامن (synchronous execution) لدالة تأثير `watchEffect` أو دالة الـ callback في `watch`: لا يمكنك استدعاؤها بعد جملة `await` في دالة غير متزامنة (async).
 
-Alternatively, an `onCleanup` function is also passed to watcher callbacks as the 3rd argument<span class="composition-api">, and to the `watchEffect` effect function as the first argument</span>:
+بدلاً من ذلك، تُمرَّر أيضًا دالة `onCleanup` إلى دوال الـ callback للمراقب كالوسيط الثالث<span class="composition-api">، وإلى دالة تأثير `watchEffect` كأول وسيط</span>:
 
 <div class="composition-api">
 
@@ -451,14 +451,14 @@ Alternatively, an `onCleanup` function is also passed to watcher callbacks as th
 watch(id, (newId, oldId, onCleanup) => {
   // ...
   onCleanup(() => {
-    // cleanup logic
+    // منطق التنظيف
   })
 })
 
 watchEffect((onCleanup) => {
   // ...
   onCleanup(() => {
-    // cleanup logic
+    // منطق التنظيف
   })
 })
 ```
@@ -472,7 +472,7 @@ export default {
     id(newId, oldId, onCleanup) {
       // ...
       onCleanup(() => {
-        // cleanup logic
+        // منطق التنظيف
       })
     }
   }
@@ -481,19 +481,19 @@ export default {
 
 </div>
 
-This works in versions before 3.5. In addition, `onCleanup` passed via function argument is bound to the watcher instance so it is not subject to the synchronously constraint of `onWatcherCleanup`.
+يعمل هذا في الإصدارات السابقة لـ 3.5. بالإضافة إلى ذلك، الـ `onCleanup` الممرَّرة عبر وسيط الدالة مرتبطة بنسخة المراقب (watcher) وليست خاضعة لقيد التزامن (synchronous constraint) الخاص بـ `onWatcherCleanup`.
 
 ## توقيت تنفيذ الدالة المعالجة {#callback-flush-timing}
 
 لما تُعدل حالة تفاعلية، فإنها قد تُشغل كل من تحديثات مكونات Vue والدوال المراقِبة المُنشأة من قبلك.
 
-Similar to component updates, user-created watcher callbacks are batched to avoid duplicate invocations. For example, we probably don't want a watcher to fire a thousand times if we synchronously push a thousand items into an array being watched.
+بمثل تحديثات المكون، تُجمَّع دوال الـ callback للمراقبين التي أنشأها المستخدم لتجنب استدعاءات مكررة. على سبيل المثال، قد لا نريد أن يُنفَّذ المراقب ألف مرة إذا دفعنا ألف عنصر بشكل متزامن إلى مصفوفة يتم مراقبتها.
 
-By default, a watcher's callback is called **after** parent component updates (if any), and **before** the owner component's DOM updates. This means if you attempt to access the owner component's own DOM inside a watcher callback, the DOM will be in a pre-update state.
+افتراضيًا، تُستدعى دالة الـ callback للمراقب **بعد** تحديثات المكون الأب (إن وُجدت)، و**قبل** تحديثات DOM للمكون المالك. هذا يعني أنه إذا حاولت الوصول إلى DOM المكون المالك نفسه داخل callback المراقب، فسيكون الـ DOM في حالة ما قبل التحديث (pre-update state).
 
-### Post Watchers {#post-watchers}
+### مراقبون بعد التحديث (post watchers) {#post-watchers}
 
-If you want to access the owner component's DOM in a watcher callback **after** Vue has updated it, you need to specify the `flush: 'post'` option:
+إذا أردت الوصول إلى DOM المكون المالك داخل callback المراقب **بعد** أن تُحدِّثه Vue، فستحتاج إلى تحديد الخيار `flush: 'post'`:
 
 <div class="options-api">
 
@@ -535,9 +535,9 @@ watchPostEffect(() => {
 
 </div>
 
-### Sync Watchers {#sync-watchers}
+### مراقبون متزامنون (sync watchers) {#sync-watchers}
 
-It's also possible to create a watcher that fires synchronously, before any Vue-managed updates:
+من الممكن أيضًا إنشاء مراقب يُنفَّذ بشكل متزامن، قبل أي تحديثات تديرها Vue:
 
 <div class="options-api">
 
@@ -567,20 +567,20 @@ watchEffect(callback, {
 })
 ```
 
-Sync `watchEffect()` also has a convenience alias, `watchSyncEffect()`:
+لدى استدعاء `watchEffect()` المتزامن أيضًا اسم بديل مريح، وهو `watchSyncEffect()`:
 
 ```js
 import { watchSyncEffect } from 'vue'
 
 watchSyncEffect(() => {
-  /* executed synchronously upon reactive data change */
+  /* يُنفَّذ بشكل متزامن عند تغيّر البيانات التفاعلية */
 })
 ```
 
 </div>
 
-:::warning Use with Caution
-Sync watchers do not have batching and triggers every time a reactive mutation is detected. It's ok to use them to watch simple boolean values, but avoid using them on data sources that might be synchronously mutated many times, e.g. arrays.
+:::warning استخدم بحذر
+لا تمتلك المراقبات المتزامنة (sync watchers) تجميعًا (batching) وتُطلَق في كل مرة يُكتشف فيها تحوّر تفاعلي (reactive mutation). يمكن استخدامها لمراقبة قيم منطقية بسيطة، لكن تجنب استخدامها على مصادر بيانات قد تُعدَّل بشكل متزامن عدة مرات، مثل المصفوفات.
 :::
 
 <div class="options-api">

--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -217,11 +217,12 @@ watch(
 
 </div>
 
-In Vue 3.5+, the `deep` option can also be a number indicating the max traversal depth - i.e. how many levels should Vue traverse an object's nested properties.
+في Vue 3.5 وما فوق، يمكن أن يكون خيار `deep` أيضًا رقمًا يحدد أقصى عمق للتفحص (max traversal depth) — أي عدد المستويات التي يجب أن يجتازها Vue داخل خصائص الكائن المتداخلة.
 
-:::warning Use with Caution
-Deep watch requires traversing all nested properties in the watched object, and can be expensive when used on large data structures. Use it only when necessary and beware of the performance implications.
+:::warning تحذير
+المراقبة العميقة (deep watch) تتطلب المرور على جميع الخصائص المتداخلة داخل الكائن المُراقَب، وقد تكون مكلفة من ناحية الأداء عند استخدامها مع هياكل بيانات كبيرة. استخدمها فقط عند الضرورة وكن على دراية بتأثيرها على الأداء.
 :::
+
 
 ## الدوال المُراقِبة الفورية {#eager-watchers}
 
@@ -263,11 +264,13 @@ watch(source, (newValue, oldValue) => {
 
 </div>
 
-## Once Watchers {#once-watchers}
+## المراقبة لمرة واحدة {#once-watchers}
 
-- Only supported in 3.4+
+- مدعومة فقط في الإصدار 3.4 وما فوق
 
-Watcher's callback will execute whenever the watched source changes. If you want the callback to trigger only once when the source changes, use the `once: true` option.
+يتم تنفيذ دالة الـ callback الخاصة بالـ watcher كلما تغيّر المصدر المُراقَب.  
+إذا كنت تريد تشغيل الـ callback مرة واحدة فقط عند أول تغيير في المصدر، استخدم الخيار `once: true`.
+
 
 <div class="options-api">
 
@@ -355,9 +358,10 @@ watchEffect(async () => {
 
 </div>
 
-## Side Effect Cleanup {#side-effect-cleanup}
+## تنظيف التأثيرات الجانبية {#side-effect-cleanup}
 
-Sometimes we may perform side effects, e.g. asynchronous requests, in a watcher:
+في بعض الأحيان قد نقوم بتنفيذ تأثيرات جانبية (side effects)، مثل الطلبات غير المتزامنة (asynchronous requests)، داخل الـ watcher:
+
 
 <div class="composition-api">
 
@@ -386,9 +390,11 @@ export default {
 
 </div>
 
-But what if `id` changes before the request completes? When the previous request completes, it will still fire the callback with an ID value that is already stale. Ideally, we want to be able to cancel the stale request when `id` changes to a new value.
+لكن ماذا لو تغيّر `id` قبل اكتمال الطلب؟ عند انتهاء الطلب السابق، سيقوم بتشغيل الـ callback باستخدام قيمة `id` أصبحت قديمة بالفعل (stale).  
+في الحالة المثالية، نريد إلغاء الطلب القديم عندما يتغير `id` إلى قيمة جديدة.
 
-We can use the [`onWatcherCleanup()`](/api/reactivity-core#onwatchercleanup) <sup class="vt-badge" data-text="3.5+" /> API to register a cleanup function that will be called when the watcher is invalidated and is about to re-run:
+يمكننا استخدام واجهة [`onWatcherCleanup()`](/api/reactivity-core#onwatchercleanup) <sup class="vt-badge" data-text="3.5+" /> لتسجيل دالة تنظيف (cleanup function)، والتي سيتم استدعاؤها عندما يتم إبطال الـ watcher وقبل إعادة تشغيله:
+
 
 <div class="composition-api">
 

--- a/src/guide/essentials/watchers.md
+++ b/src/guide/essentials/watchers.md
@@ -100,7 +100,7 @@ watch(question, async (newQuestion) => {
 
 ### أنواع مصادر الدالة المُراقبة {#watch-source-types}
 
-`watch`'s first argument can be different types of reactive "sources": it can be a ref (including computed refs), a reactive object, a [getter function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get#description), or an array of multiple sources:
+يمكن أن تكون الوسيطة الأولى في `watch` أنواعًا مختلفة من "المصادر" التفاعلية (reactive sources): يمكن أن تكون `ref` (بما في ذلك المراجع المحسوبة)، أو كائن تفاعلي (reactive object)، أو [دالة getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get#description)، أو مصفوفة تحتوي على عدة مصادر.
 
 ```js
 const x = ref(0)
@@ -190,7 +190,8 @@ watch(obj, (newValue, oldValue) => {
 obj.count++
 ```
 
-This should be differentiated with a getter that returns a reactive object - in the latter case, the callback will only fire if the getter returns a different object:
+يجب التمييز بين هذا وبين دالة getter التي تُرجع كائنًا تفاعليًا (reactive object) — في هذه الحالة الأخيرة، لن يتم تشغيل الـ callback إلا إذا أعادت دالة الـ getter كائنًا مختلفًا.
+
 
 ```js
 watch(


### PR DESCRIPTION
## Description of Problem
Several sections across the Essentials guide pages still contained untranslated English paragraphs, section headings, code comments, and callouts, breaking the reading experience for Arabic documentation users.
Affected files:
src/guide/essentials/watchers.md
src/guide/essentials/template-refs.md
src/guide/essentials/template-syntax.md
src/guide/essentials/component-basics.md
src/guide/essentials/reactivity-fundamentals.md
src/guide/essentials/computed.md

## Proposed Solution
Translated all remaining English passages in the above files into Arabic, including:

Section headings and subheadings
Paragraph text and callouts (notes, warnings, tips)
Code comments inside examples
<summary> labels in <details> blocks
Playground links text ("Try it in the Playground")
Technical terms are kept alongside their English equivalents in parentheses where needed (e.g. كائن تفاعلي (reactive object)), following the project's translation conventions. All Markdown structure, anchors, and links are preserved unchanged. Also fixed a duplicated paragraph in reactivity-fundamentals.md and a typo in watchers.md.

## Additional Information
No technical content or structure was changed — purely translation work.