### PR TITLE
fix: add self-closing slash to v-model with argument and modifier example (#422)

### DIFF
--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -529,7 +529,7 @@ export default {
 For `v-model` bindings with both argument and modifiers, the generated prop name will be `arg + "Modifiers"`. For example:
 
 ```vue-html
-<MyComponent v-model:title.capitalize="myText">
+<MyComponent v-model:title.capitalize="myText" />
 ```
 
 التصريحات المقابلة يجب أن تكون:


### PR DESCRIPTION
resolves #422
Cherry picked from https://github.com/vuejs/docs/commit/142fa3cc918500c8829c7d0abdd5e3e2ab7a72bc