### PR TITLE
fix: change js to ts code fence for Options API emits TypeScript example (#424)

### DIFF
--- a/src/guide/components/events.md
+++ b/src/guide/components/events.md
@@ -208,7 +208,7 @@ const emit = defineEmits<{
 </div>
 <div class="options-api">
 
-```js
+```ts
 export default {
   emits: {
     submit(payload: { email: string, password: string }) {

--- a/src/guide/components/v-model.md
+++ b/src/guide/components/v-model.md
@@ -529,7 +529,7 @@ export default {
 For `v-model` bindings with both argument and modifiers, the generated prop name will be `arg + "Modifiers"`. For example:
 
 ```vue-html
-<MyComponent v-model:title.capitalize="myText">
+<MyComponent v-model:title.capitalize="myText" />
 ```
 
 التصريحات المقابلة يجب أن تكون:


### PR DESCRIPTION
resolves #424
Cherry picked from https://github.com/vuejs/docs/commit/c3046b456388d67751f0d71f06950fb468a30310